### PR TITLE
make allow project's authWebhookURL to become for ''

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -65,7 +65,12 @@ function validateAuthWebhookUrl(authWebhookUrl: string): boolean {
 
 export function validateUpdatableProjectFields(fields: UpdatableProjectFields): boolean {
   if (typeof fields.name !== 'undefined' && !validateName(fields.name)) return false;
-  if (typeof fields.authWebhookURL !== 'undefined' && !validateAuthWebhookUrl(fields.authWebhookURL)) return false;
+  if (
+    typeof fields.authWebhookURL !== 'undefined' &&
+    fields.authWebhookURL !== '' &&
+    !validateAuthWebhookUrl(fields.authWebhookURL)
+  )
+    return false;
 
   return true;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
what
- make allow project's authWebhookURL to become for ''
why
- Currently, once a project's authWebhookURL is updated, authWebhookURL cannot be removed

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
