### PR TITLE
Fix routing after logging in

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,8 +47,8 @@ function App() {
           <Route path="/projects/:projectName/documents" element={<DocumentsPage />}>
             <Route path=":documentKey" element={<DocumentDetail />} />
           </Route>
-          <Route path="*" element={<NotFoundPage />} />
         </Route>
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </Router>
   );

--- a/src/features/globalError/ErrorModal.tsx
+++ b/src/features/globalError/ErrorModal.tsx
@@ -15,31 +15,19 @@
  */
 
 import React, { useState, useCallback, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
 import { selectGlobalError, resetGlobalError } from './globalErrorSlice';
-import { logoutUser } from 'features/users/usersSlice';
 import { Modal } from 'components';
-import { RPCStatusCode } from 'api/types';
 
 export function ErrorModal() {
   const [isOpen, setIsOpen] = useState(false);
   const dispatch = useAppDispatch();
   const { code, title, message } = useAppSelector(selectGlobalError);
-  const navigate = useNavigate();
-  const location = useLocation();
 
   const closeModal = useCallback(() => {
     setIsOpen(false);
     dispatch(resetGlobalError());
   }, [dispatch]);
-
-  const moveToLogin = useCallback(() => {
-    setIsOpen(false);
-    dispatch(logoutUser());
-    dispatch(resetGlobalError());
-    navigate('/login', { state: { from: location.pathname } });
-  }, [navigate, dispatch, location.pathname]);
 
   useEffect(() => {
     if (code) {
@@ -48,18 +36,5 @@ export function ErrorModal() {
   }, [code]);
 
   if (!isOpen) return null;
-  if (code === RPCStatusCode.UNAUTHENTICATED) {
-    return (
-      <Modal
-        title={title!}
-        message={message!}
-        onClose={closeModal}
-        button={{
-          buttonText: 'Login Again',
-          onClick: moveToLogin,
-        }}
-      />
-    );
-  }
   return <Modal title={title!} message={message!} onClose={closeModal} />;
 }

--- a/src/features/globalError/globalErrorSlice.ts
+++ b/src/features/globalError/globalErrorSlice.ts
@@ -43,8 +43,8 @@ export const globalErrorSlice = createSlice({
           state.message = 'This request takes too long to process.';
           break;
         case RPCStatusCode.UNAUTHENTICATED:
-          state.title = 'Session has expired';
-          state.message = 'Your session has timed out. Please log in again.';
+          state.title = 'Authentication failed';
+          state.message = 'You do not have permission to access or your session has timed out. Please sign in.';
           break;
         default:
           state.title = 'Error';

--- a/src/features/users/LoginForm.tsx
+++ b/src/features/users/LoginForm.tsx
@@ -52,8 +52,8 @@ export function LoginForm() {
   }, [error, setError]);
 
   useEffect(() => {
-    const { from } = (location.state as { from: string }) || { from: '/' };
     if (isSuccess) {
+      const { from } = (location.state as { from: string }) || { from: '/' };
       navigate(from);
     }
   }, [navigate, isSuccess, location]);

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -15,19 +15,21 @@
  */
 
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useAppSelector } from 'app/hooks';
 import { LoginForm } from 'features/users/LoginForm';
 import { PageTemplate } from './PageTemplate';
 
 export function LoginPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { token } = useAppSelector((state) => state.users);
+
   useEffect(() => {
-    if (token) {
+    if (token && !location.state) {
       navigate('/projects');
     }
-  }, [token, navigate]);
+  }, [token, navigate, location]);
 
   return (
     <PageTemplate>

--- a/src/pages/PrivateRoute.tsx
+++ b/src/pages/PrivateRoute.tsx
@@ -15,19 +15,21 @@
  */
 
 import React, { useEffect } from 'react';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 
 import { useAppSelector } from 'app/hooks';
 import { PageTemplate } from 'pages/PageTemplate';
 
 export function PrivateRoute() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { token } = useAppSelector((state) => state.users);
+
   useEffect(() => {
     if (!token) {
-      navigate('/login');
+      navigate('/login', { state: { from: location.pathname } });
     }
-  }, [token, navigate]);
+  }, [token, navigate, location]);
 
   return (
     <PageTemplate>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

- [x] Return the user back to the page they were on after logging in.
- [x] Remove the move-to-login button in the modal because the router handles navigating to the login page when there is no token.

#### Any background context you want to provide?

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
