### PR TITLE
Fix issue that Auth fail popup is constantly exposed on the login page

### DIFF
--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -18,7 +18,7 @@ import type { Action, PayloadAction, SerializedError, MiddlewareAPI, Middleware 
 import { isRejectedWithValue } from '@reduxjs/toolkit';
 import { RPCStatusCode, APIErrorName } from 'api/types';
 import { setGlobalError } from 'features/globalError/globalErrorSlice';
-import { loginUser, signupUser } from 'features/users/usersSlice';
+import { loginUser, signupUser, setIsValidToken } from 'features/users/usersSlice';
 import { createProjectAsync, updateProjectAsync } from 'features/projects/projectsSlice';
 
 type RejectedAction = PayloadAction<
@@ -86,5 +86,8 @@ export const globalErrorHandler: Middleware = (store: MiddlewareAPI) => (next) =
     throw action.error;
   }
   if (isHandledError(action.type, statusCode)) return;
+  if (statusCode === RPCStatusCode.UNAUTHENTICATED) {
+    store.dispatch(setIsValidToken(false));
+  }
   store.dispatch(setGlobalError({ statusCode, errorMessage }));
 };

--- a/src/features/users/AccountButton.tsx
+++ b/src/features/users/AccountButton.tsx
@@ -14,21 +14,24 @@
  * limitations under the License.
  */
 import React, { useRef, useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { useAppSelector, useAppDispatch } from 'app/hooks';
-import { logoutUser } from 'features/users/usersSlice';
+import { logoutUser, selectUsers } from 'features/users/usersSlice';
 import { useOutsideClick } from 'hooks';
 
 export function AccountButton() {
-  const { token, username } = useAppSelector((state) => state.users);
+  const { username } = useAppSelector(selectUsers);
   const userDropdownRef = useRef<HTMLDivElement | null>(null);
   const userDropdownButtonRef = useRef<HTMLButtonElement | null>(null);
   const [isUserDropdownOpen, setIsUserDropdownOpen] = useState(false);
 
+  const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const logout = useCallback(() => {
     dispatch(logoutUser());
-  }, [dispatch]);
+    navigate('/login');
+  }, [dispatch, navigate]);
 
   useOutsideClick(
     userDropdownRef,
@@ -37,10 +40,6 @@ export function AccountButton() {
     },
     userDropdownButtonRef,
   );
-
-  if (!token) {
-    return null;
-  }
 
   return (
     <>

--- a/src/features/users/usersSlice.ts
+++ b/src/features/users/usersSlice.ts
@@ -22,6 +22,7 @@ import jwt_decode from 'jwt-decode';
 
 export interface UsersState {
   token: string;
+  isValidToken: boolean;
   username: string;
   login: {
     isSuccess: boolean;
@@ -58,6 +59,7 @@ type JWTPayload = {
 
 const initialState: UsersState = {
   token: localStorage.getItem('token') || '',
+  isValidToken: false,
   username: '',
   login: {
     isSuccess: false,
@@ -73,6 +75,7 @@ const initialState: UsersState = {
 
 if (initialState.token) {
   api.setToken(initialState.token);
+  initialState.isValidToken = true;
   try {
     initialState.username = jwt_decode<JWTPayload>(initialState.token).username;
   } catch (error) {
@@ -98,15 +101,20 @@ export const usersSlice = createSlice({
       localStorage.removeItem('token');
       api.setToken('');
       state.token = '';
+      state.isValidToken = false;
       state.username = '';
       state.login.status = 'idle';
       state.login.isSuccess = false;
       state.login.error = null;
     },
+    setIsValidToken: (state, action) => {
+      state.isValidToken = action.payload;
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(loginUser.fulfilled, (state, action) => {
       state.token = action.payload;
+      state.isValidToken = true;
       state.username = jwt_decode<JWTPayload>(action.payload).username;
       state.login.status = 'idle';
       state.login.isSuccess = true;
@@ -145,7 +153,7 @@ export const usersSlice = createSlice({
   },
 });
 
-export const { logoutUser } = usersSlice.actions;
+export const { logoutUser, setIsValidToken } = usersSlice.actions;
 
 export const selectUsers = (state: RootState) => state.users;
 

--- a/src/pages/Header.tsx
+++ b/src/pages/Header.tsx
@@ -17,10 +17,14 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
+import { useAppSelector } from 'app/hooks';
 import { AccountButton } from 'features/users/AccountButton';
 import { ProjectDropdown } from 'features/projects';
+import { selectUsers } from 'features/users/usersSlice';
 
 export function Header() {
+  const { token, isValidToken } = useAppSelector(selectUsers);
+
   return (
     <nav className="bg-white border-gray-200 py-1 px-2 sm:px-4 rounded">
       <div className="flex flex-wrap justify-between items-center mx-auto">
@@ -41,9 +45,9 @@ export function Header() {
               />
             </svg>
           </Link>
-          <ProjectDropdown />
+          {token && isValidToken && <ProjectDropdown />}
         </div>
-        <AccountButton />
+        {token && isValidToken && <AccountButton />}
       </div>
     </nav>
   );

--- a/src/pages/PrivateRoute.tsx
+++ b/src/pages/PrivateRoute.tsx
@@ -19,17 +19,18 @@ import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 
 import { useAppSelector } from 'app/hooks';
 import { PageTemplate } from 'pages/PageTemplate';
+import { selectUsers } from 'features/users/usersSlice';
 
 export function PrivateRoute() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { token } = useAppSelector((state) => state.users);
+  const { token, isValidToken } = useAppSelector(selectUsers);
 
   useEffect(() => {
-    if (!token) {
+    if (!token || !isValidToken) {
       navigate('/login', { state: { from: location.pathname } });
     }
-  }, [token, navigate, location]);
+  }, [token, navigate, location, isValidToken]);
 
   return (
     <PageTemplate>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fix the issue that Auth fail popup is constantly exposed on the login page.
An authentication error occurred because authentication is required in the header.
I resolved it by setting ProjectDropdown and AccountButton components 
to show only if the token exists and is valid.


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #55 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
