### PR TITLE
Bump Yorkie JS SDK to v0.7.3

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # Common Environment Variables
-VITE_JS_SDK_VERSION=0.7.2
+VITE_JS_SDK_VERSION=0.7.3
 VITE_GITHUB_AUTH_ENABLED=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "dependencies": {
         "@buf/googleapis_googleapis.connectrpc_es": "^1.4.0-20240524201209-f0e53af8f2fc.3",
         "@bufbuild/buf": "^1.34.0",
@@ -25,7 +25,7 @@
         "@uiw/react-codemirror": "^4.23.10",
         "@vitejs/plugin-react": "^4.3.1",
         "@yorkie-js/schema": "^0.7.1",
-        "@yorkie-js/sdk": "^0.7.2",
+        "@yorkie-js/sdk": "^0.7.3",
         "autoprefixer": "^10.4.19",
         "classnames": "^2.5.1",
         "date-fns": "^3.6.0",
@@ -2469,20 +2469,20 @@
       }
     },
     "node_modules/@yorkie-js/schema": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/schema/-/schema-0.7.1.tgz",
-      "integrity": "sha512-r/XR+M1lerJg3+AbCfKugsKz4ZNkp0aeP+d/5AMYfZQClyt7V0dj4RXTmGhhSpbzR9JjExmOKg7Ro2OIQ8YiUw=="
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/schema/-/schema-0.7.3.tgz",
+      "integrity": "sha512-nup7k8KzbjxSlXIpTRfl2R2N33S2UTbJnRLneQwKeqWA+cuRJl2Y3sX5jcAYWMt/OzbrM9AvdKMXLfZWgPMD7g=="
     },
     "node_modules/@yorkie-js/sdk": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.2.tgz",
-      "integrity": "sha512-8rH2sqwGslKPo0igyQi1NSkPurmEy0S5A8GLVceRu1EoprNkzAia8/64qng9+GnB6H4aoQCH9DKW+ggVK1uFAQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.3.tgz",
+      "integrity": "sha512-F6Gx2PQAeRTrPE5OJp9neKOTSqu19/TAjcQfLg/nXRJXldEg0Ov6BczeY8NR7o1Wq8ehIntK8OiwARp/fvGMdA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.10.1",
         "@connectrpc/connect": "^2.1.1",
         "@connectrpc/connect-web": "^2.1.1",
-        "@yorkie-js/schema": "0.7.1",
+        "@yorkie-js/schema": "0.7.3",
         "long": "^5.3.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "type": "module",
   "homepage": "https://yorkie.dev/dashboard",
@@ -22,7 +22,7 @@
     "@uiw/react-codemirror": "^4.23.10",
     "@vitejs/plugin-react": "^4.3.1",
     "@yorkie-js/schema": "^0.7.1",
-    "@yorkie-js/sdk": "^0.7.2",
+    "@yorkie-js/sdk": "^0.7.3",
     "autoprefixer": "^10.4.19",
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
Bump Yorkie JS SDK to v0.7.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 0.7.3 and bumped the JavaScript SDK dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->