### PR TITLE
Bump version to v0.7.5

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # Common Environment Variables
-VITE_JS_SDK_VERSION=0.7.4
+VITE_JS_SDK_VERSION=0.7.5
 VITE_GITHUB_AUTH_ENABLED=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "homepage": "https://yorkie.dev/dashboard",


### PR DESCRIPTION
## Summary
- Bump `version` in package.json to 0.7.5
- Bump `VITE_JS_SDK_VERSION` in .env to 0.7.5

## Test plan
- [x] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)