### PR TITLE
Bump Yorkie JS SDK to v0.7.7

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # Common Environment Variables
-VITE_JS_SDK_VERSION=0.7.6
+VITE_JS_SDK_VERSION=0.7.7
 VITE_GITHUB_AUTH_ENABLED=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "type": "module",
   "homepage": "https://yorkie.dev/dashboard",
@@ -22,7 +22,7 @@
     "@uiw/react-codemirror": "^4.23.10",
     "@vitejs/plugin-react": "^4.3.1",
     "@yorkie-js/schema": "^0.7.1",
-    "@yorkie-js/sdk": "^0.7.3",
+    "@yorkie-js/sdk": "^0.7.7",
     "autoprefixer": "^10.4.19",
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
## Summary
- Bump `@yorkie-js/sdk` to v0.7.7
- Update `VITE_JS_SDK_VERSION` to 0.7.7