### PR TITLE
Link docs hierarchy from README so all .md files are reachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,10 @@ $ npm run dev
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details on submitting patches and the contribution workflow.
+
+## Documentation
+
+- [docs/design/](docs/design/README.md) — Architectural design documents
+- [docs/tasks/](docs/tasks/README.md) — Task tracking (active and archived)
+- [MAINTAINING.md](MAINTAINING.md) — Release and maintenance procedures
+- [CLAUDE.md](CLAUDE.md) — Agent instructions for AI-assisted development

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,8 +1,8 @@
 ---
-updated: 2026-03-25
+updated: 2026-04-29
 ---
 
 # Tasks
 
-- `active/` — In-progress tasks
-- `archive/` — Completed tasks
+- [active/](active/README.md) — In-progress tasks
+- [archive/](archive/README.md) — Completed tasks


### PR DESCRIPTION
## Summary

- Add a Documentation section to \`README.md\` linking \`docs/design/\`, \`docs/tasks/\`, \`MAINTAINING.md\`, and \`CLAUDE.md\` so they are reachable from the project's entry point.
- Convert inline-code path references in \`docs/tasks/README.md\` to real markdown links so the parent README points at the children correctly.

Found via the link connectivity check script being added to second-brain ([yorkie-team/second-brain#34](https://github.com/yorkie-team/second-brain/pull/34)). Before this change, 11 \`.md\` files in this repo had no incoming link from the README graph; after, only the \`.github/\` issue/PR templates remain (which are used by GitHub UI rather than navigated as docs).

## Test plan

- [x] Verified the new links resolve to existing files
- [x] Confirmed \`docs/design/README.md\` already linked its children, so no further edits needed there
- [ ] Reviewer to spot-check the new Documentation section reads naturally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with new documentation navigation section.
  * Enhanced internal documentation structure with direct links to referenced sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->