### PR TITLE
Bump Yorkie JS SDK to v0.7.8

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # Common Environment Variables
-VITE_JS_SDK_VERSION=0.7.7
+VITE_JS_SDK_VERSION=0.7.8
 VITE_GITHUB_AUTH_ENABLED=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.7.6",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.7.6",
+      "version": "0.7.8",
       "dependencies": {
         "@buf/googleapis_googleapis.connectrpc_es": "^1.4.0-20240524201209-f0e53af8f2fc.3",
         "@bufbuild/buf": "^1.34.0",
@@ -25,7 +25,7 @@
         "@uiw/react-codemirror": "^4.23.10",
         "@vitejs/plugin-react": "^4.3.1",
         "@yorkie-js/schema": "^0.7.1",
-        "@yorkie-js/sdk": "^0.7.3",
+        "@yorkie-js/sdk": "^0.7.8",
         "autoprefixer": "^10.4.19",
         "classnames": "^2.5.1",
         "date-fns": "^3.6.0",
@@ -2469,24 +2469,23 @@
       }
     },
     "node_modules/@yorkie-js/schema": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/schema/-/schema-0.7.3.tgz",
-      "integrity": "sha512-nup7k8KzbjxSlXIpTRfl2R2N33S2UTbJnRLneQwKeqWA+cuRJl2Y3sX5jcAYWMt/OzbrM9AvdKMXLfZWgPMD7g=="
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/schema/-/schema-0.7.8.tgz",
+      "integrity": "sha512-KcEt3VBM5Pax8w3xs8/uFBttCknkpGeRBoB9NN+f0+2PEmXfB9NdGRAxpMXqe3Nq+P0+bDrTId32T3fc5WdxJg=="
     },
     "node_modules/@yorkie-js/sdk": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.3.tgz",
-      "integrity": "sha512-F6Gx2PQAeRTrPE5OJp9neKOTSqu19/TAjcQfLg/nXRJXldEg0Ov6BczeY8NR7o1Wq8ehIntK8OiwARp/fvGMdA==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.8.tgz",
+      "integrity": "sha512-Ptaog0agLLgpWQCudiUMFYBYnLG45hVwXM1OOTO4K14j/uUPbamJ40j7h2LkMEqRqtRECIlR7b65yLUc9KH0hA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.10.1",
         "@connectrpc/connect": "^2.1.1",
         "@connectrpc/connect-web": "^2.1.1",
-        "@yorkie-js/schema": "0.7.3",
-        "long": "^5.3.2"
+        "@yorkie-js/schema": "0.7.8"
       },
       "engines": {
-        "node": ">=18.0.0",
+        "node": "^20.19.0 || >=22.12.0",
         "npm": ">=7.1.0",
         "pnpm": ">=9.6.0"
       }
@@ -4129,12 +4128,6 @@
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
-    },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "type": "module",
   "homepage": "https://yorkie.dev/dashboard",
@@ -22,7 +22,7 @@
     "@uiw/react-codemirror": "^4.23.10",
     "@vitejs/plugin-react": "^4.3.1",
     "@yorkie-js/schema": "^0.7.1",
-    "@yorkie-js/sdk": "^0.7.7",
+    "@yorkie-js/sdk": "^0.7.8",
     "autoprefixer": "^10.4.19",
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
## Summary

Bump `@yorkie-js/sdk` to v0.7.8.

## Test plan

- [x] `npm install` updates lockfile
- [x] `npm run build` succeeds
- [ ] CI passes