### PR TITLE
Bump Yorkie JS SDK to v0.7.9

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # Common Environment Variables
-VITE_JS_SDK_VERSION=0.7.8
+VITE_JS_SDK_VERSION=0.7.9
 VITE_GITHUB_AUTH_ENABLED=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "dependencies": {
         "@buf/googleapis_googleapis.connectrpc_es": "^1.4.0-20240524201209-f0e53af8f2fc.3",
         "@bufbuild/buf": "^1.34.0",
@@ -25,7 +25,7 @@
         "@uiw/react-codemirror": "^4.23.10",
         "@vitejs/plugin-react": "^4.3.1",
         "@yorkie-js/schema": "^0.7.1",
-        "@yorkie-js/sdk": "^0.7.8",
+        "@yorkie-js/sdk": "^0.7.9",
         "autoprefixer": "^10.4.19",
         "classnames": "^2.5.1",
         "date-fns": "^3.6.0",
@@ -2469,20 +2469,20 @@
       }
     },
     "node_modules/@yorkie-js/schema": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/schema/-/schema-0.7.8.tgz",
-      "integrity": "sha512-KcEt3VBM5Pax8w3xs8/uFBttCknkpGeRBoB9NN+f0+2PEmXfB9NdGRAxpMXqe3Nq+P0+bDrTId32T3fc5WdxJg=="
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/schema/-/schema-0.7.9.tgz",
+      "integrity": "sha512-qdk3rgRGExpD6owC7v8QbPBno501jflrsh4fzT9NQsZkdKcqcWz8ggictvx5OQXmIxDS5KZzUcK3Nsn4ZpVYcA=="
     },
     "node_modules/@yorkie-js/sdk": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.8.tgz",
-      "integrity": "sha512-Ptaog0agLLgpWQCudiUMFYBYnLG45hVwXM1OOTO4K14j/uUPbamJ40j7h2LkMEqRqtRECIlR7b65yLUc9KH0hA==",
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.9.tgz",
+      "integrity": "sha512-fWc47HPBNaaF0up33vlOAXrycCGFxA6P9WrJDgollIDomT3JyDHzfe4Vo0P5nqQDIsqYkd6UdAkD3q7H0nW3yQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.10.1",
         "@connectrpc/connect": "^2.1.1",
         "@connectrpc/connect-web": "^2.1.1",
-        "@yorkie-js/schema": "0.7.8"
+        "@yorkie-js/schema": "0.7.9"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "type": "module",
   "homepage": "https://yorkie.dev/dashboard",
@@ -22,7 +22,7 @@
     "@uiw/react-codemirror": "^4.23.10",
     "@vitejs/plugin-react": "^4.3.1",
     "@yorkie-js/schema": "^0.7.1",
-    "@yorkie-js/sdk": "^0.7.8",
+    "@yorkie-js/sdk": "^0.7.9",
     "autoprefixer": "^10.4.19",
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
## Summary

Bump `@yorkie-js/sdk` to v0.7.9.

## Test plan

- [x] `npm run build` passes
- [x] Verify dashboard runs against v0.7.9 SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.7.9 released with updated SDK dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/dashboard/pull/296)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->