### PR TITLE
Bump Yorkie JS SDK to v0.7.10

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # Common Environment Variables
-VITE_JS_SDK_VERSION=0.7.9
+VITE_JS_SDK_VERSION=0.7.10
 VITE_GITHUB_AUTH_ENABLED=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "dependencies": {
         "@buf/googleapis_googleapis.connectrpc_es": "^1.4.0-20240524201209-f0e53af8f2fc.3",
         "@bufbuild/buf": "^1.34.0",
@@ -25,7 +25,7 @@
         "@uiw/react-codemirror": "^4.23.10",
         "@vitejs/plugin-react": "^4.3.1",
         "@yorkie-js/schema": "^0.7.1",
-        "@yorkie-js/sdk": "^0.7.9",
+        "@yorkie-js/sdk": "^0.7.10",
         "autoprefixer": "^10.4.19",
         "classnames": "^2.5.1",
         "date-fns": "^3.6.0",
@@ -2469,20 +2469,20 @@
       }
     },
     "node_modules/@yorkie-js/schema": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/schema/-/schema-0.7.9.tgz",
-      "integrity": "sha512-qdk3rgRGExpD6owC7v8QbPBno501jflrsh4fzT9NQsZkdKcqcWz8ggictvx5OQXmIxDS5KZzUcK3Nsn4ZpVYcA=="
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/schema/-/schema-0.7.10.tgz",
+      "integrity": "sha512-0goo53iEv2GI9g0pVEb+rvcJddC632WtHAtmL3z+MwHZTlfw2mvYwVTVwEoeMjVDSAU6WNODriS1Z7kowmOW+g=="
     },
     "node_modules/@yorkie-js/sdk": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.9.tgz",
-      "integrity": "sha512-fWc47HPBNaaF0up33vlOAXrycCGFxA6P9WrJDgollIDomT3JyDHzfe4Vo0P5nqQDIsqYkd6UdAkD3q7H0nW3yQ==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.10.tgz",
+      "integrity": "sha512-kifdG/mLoHn8Uwb+c/v2jpYMM/WBwnDawnL2tuTggpFbxoVYMgUWzjF01EUGWnhffi/DH5NefbsovBqeEd2BuA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.10.1",
         "@connectrpc/connect": "^2.1.1",
         "@connectrpc/connect-web": "^2.1.1",
-        "@yorkie-js/schema": "0.7.9"
+        "@yorkie-js/schema": "0.7.10"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "private": true,
   "type": "module",
   "homepage": "https://yorkie.dev/dashboard",
@@ -22,7 +22,7 @@
     "@uiw/react-codemirror": "^4.23.10",
     "@vitejs/plugin-react": "^4.3.1",
     "@yorkie-js/schema": "^0.7.1",
-    "@yorkie-js/sdk": "^0.7.9",
+    "@yorkie-js/sdk": "^0.7.10",
     "autoprefixer": "^10.4.19",
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
## Summary

- Bump `@yorkie-js/sdk` to ^0.7.10
- Bump project version to 0.7.10
- Update `VITE_JS_SDK_VERSION` to 0.7.10

Release: https://github.com/yorkie-team/yorkie-js-sdk/releases/tag/v0.7.10

## Test plan

- [x] CI green
- [x] `npm run build` passes locally