### PR TITLE
Add channel session TTL field to project Settings

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -68,6 +68,7 @@ export function fromProject(pbProject: PbProject): Project {
     eventWebhookURL: pbProject.eventWebhookUrl,
     eventWebhookEvents: pbProject.eventWebhookEvents as Array<EventWebhookEvent>,
     clientDeactivateThreshold: pbProject.clientDeactivateThreshold,
+    channelSessionTtl: pbProject.channelSessionTtl,
     snapshotInterval: Number(pbProject.snapshotInterval),
     snapshotThreshold: Number(pbProject.snapshotThreshold),
     maxSubscribersPerDocument: pbProject.maxSubscribersPerDocument,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -162,6 +162,7 @@ export async function updateProject(id: string, fields: UpdatableProjectFields):
       ? new PbProjectFields_EventWebhookEvents({ events: fields.eventWebhookEvents })
       : undefined,
     clientDeactivateThreshold: fields.clientDeactivateThreshold,
+    channelSessionTtl: fields.channelSessionTtl,
     snapshotThreshold: fields.snapshotThreshold ? BigInt(fields.snapshotThreshold) : undefined,
     snapshotInterval: fields.snapshotInterval ? BigInt(fields.snapshotInterval) : undefined,
     maxSubscribersPerDocument: fields.maxSubscribersPerDocument,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -76,6 +76,7 @@ export type Project = {
   eventWebhookURL: string;
   eventWebhookEvents?: Array<EventWebhookEvent>;
   clientDeactivateThreshold: string;
+  channelSessionTtl: string;
   snapshotThreshold: number;
   snapshotInterval: number;
   maxSubscribersPerDocument: number;
@@ -139,6 +140,7 @@ export type UpdatableProjectFields = {
   eventWebhookURL?: string;
   eventWebhookEvents?: Array<EventWebhookEvent>;
   clientDeactivateThreshold?: string;
+  channelSessionTtl?: string;
   snapshotThreshold?: number;
   snapshotInterval?: number;
   maxSubscribersPerDocument?: number;

--- a/src/api/yorkie/v1/resources.proto
+++ b/src/api/yorkie/v1/resources.proto
@@ -315,6 +315,7 @@ message Project {
   int32 max_size_per_document = 15;
   bool remove_on_detach = 16;
   bool auto_revision_enabled = 27;
+  string channel_session_ttl = 28;
   repeated string allowed_origins = 14;
   google.protobuf.Timestamp created_at = 12;
   google.protobuf.Timestamp updated_at = 13;
@@ -359,6 +360,7 @@ message UpdatableProjectFields {
   google.protobuf.Int32Value max_size_per_document = 10;
   google.protobuf.BoolValue remove_on_detach = 11;
   google.protobuf.BoolValue auto_revision_enabled = 22;
+  google.protobuf.StringValue channel_session_ttl = 23;
   AllowedOrigins allowed_origins = 9;
 }
 

--- a/src/api/yorkie/v1/resources_pb.ts
+++ b/src/api/yorkie/v1/resources_pb.ts
@@ -2316,6 +2316,11 @@ export class Project extends Message<Project> {
   autoRevisionEnabled = false;
 
   /**
+   * @generated from field: string channel_session_ttl = 28;
+   */
+  channelSessionTtl = "";
+
+  /**
    * @generated from field: repeated string allowed_origins = 14;
    */
   allowedOrigins: string[] = [];
@@ -2362,6 +2367,7 @@ export class Project extends Message<Project> {
     { no: 15, name: "max_size_per_document", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
     { no: 16, name: "remove_on_detach", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
     { no: 27, name: "auto_revision_enabled", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 28, name: "channel_session_ttl", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 14, name: "allowed_origins", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
     { no: 12, name: "created_at", kind: "message", T: Timestamp },
     { no: 13, name: "updated_at", kind: "message", T: Timestamp },
@@ -2537,6 +2543,11 @@ export class UpdatableProjectFields extends Message<UpdatableProjectFields> {
   autoRevisionEnabled?: boolean;
 
   /**
+   * @generated from field: google.protobuf.StringValue channel_session_ttl = 23;
+   */
+  channelSessionTtl?: string;
+
+  /**
    * @generated from field: yorkie.v1.UpdatableProjectFields.AllowedOrigins allowed_origins = 9;
    */
   allowedOrigins?: UpdatableProjectFields_AllowedOrigins;
@@ -2570,6 +2581,7 @@ export class UpdatableProjectFields extends Message<UpdatableProjectFields> {
     { no: 10, name: "max_size_per_document", kind: "message", T: Int32Value },
     { no: 11, name: "remove_on_detach", kind: "message", T: BoolValue },
     { no: 22, name: "auto_revision_enabled", kind: "message", T: BoolValue },
+    { no: 23, name: "channel_session_ttl", kind: "message", T: StringValue },
     { no: 9, name: "allowed_origins", kind: "message", T: UpdatableProjectFields_AllowedOrigins },
   ]);
 

--- a/src/features/projects/Settings.tsx
+++ b/src/features/projects/Settings.tsx
@@ -64,6 +64,7 @@ export function Settings() {
       eventWebhookURL: '',
       eventWebhookEvents: [],
       clientDeactivateThreshold: '',
+      channelSessionTtl: '',
       snapshotInterval: 0,
       snapshotThreshold: 0,
       maxSubscribersPerDocument: 0,
@@ -95,6 +96,10 @@ export function Settings() {
   const { field: clientDeactivateThreshold, fieldState: clientDeactivateThresholdState } = useController({
     control,
     name: 'clientDeactivateThreshold',
+  });
+  const { field: channelSessionTtl, fieldState: channelSessionTtlState } = useController({
+    control,
+    name: 'channelSessionTtl',
   });
   const { field: maxSubscribersPerDocument, fieldState: maxSubscribersPerDocumentState } = useController({
     control,
@@ -149,6 +154,7 @@ export function Settings() {
       eventWebhookURL: project?.eventWebhookURL || '',
       eventWebhookEvents: project?.eventWebhookEvents || [],
       clientDeactivateThreshold: project?.clientDeactivateThreshold || '',
+      channelSessionTtl: project?.channelSessionTtl || '',
       maxSubscribersPerDocument: project?.maxSubscribersPerDocument || 0,
       maxAttachmentsPerDocument: project?.maxAttachmentsPerDocument || 0,
       snapshotInterval: project?.snapshotInterval || 0,
@@ -185,6 +191,7 @@ export function Settings() {
       !authWebhookURLFieldState.error &&
       !eventWebhookURLFieldState.error &&
       !clientDeactivateThresholdState.error &&
+      !channelSessionTtlState.error &&
       !maxSubscribersPerDocumentState.error &&
       !maxAttachmentsPerDocumentState.error &&
       !maxSizePerDocumentState.error &&
@@ -205,6 +212,7 @@ export function Settings() {
       authWebhookURLFieldState.error ||
       eventWebhookURLFieldState.error ||
       clientDeactivateThresholdState.error ||
+      channelSessionTtlState.error ||
       maxSubscribersPerDocumentState.error ||
       maxAttachmentsPerDocumentState.error ||
       maxSizePerDocumentState.error ||
@@ -228,6 +236,7 @@ export function Settings() {
     authWebhookURLFieldState.error,
     eventWebhookURLFieldState.error,
     clientDeactivateThresholdState.error,
+    channelSessionTtlState.error,
     maxSubscribersPerDocumentState.error,
     maxAttachmentsPerDocumentState.error,
     maxSizePerDocumentState.error,
@@ -669,6 +678,59 @@ export function Settings() {
                     }
                     helperText={
                       updateFieldInfo.target === 'clientDeactivateThreshold' && updateFieldInfo.state !== null
+                        ? updateFieldInfo.message
+                        : undefined
+                    }
+                    onSuccessEnd={resetUpdateFieldInfo}
+                  />
+                </div>
+              </dd>
+              <dt className="sub_title">Channel Session TTL</dt>
+              <dd className="sub_desc">
+                <p className="guide">
+                  Set how long a channel session is retained after a user leaves (1s–5m). Longer values keep users
+                  counted in presence longer after they disconnect, increasing the apparent live presence count.
+                  Format: &quot;15s&quot; for 15 seconds, &quot;1m30s&quot; for 1 minute 30 seconds.
+                </p>
+                <div
+                  className={classNames('input_field_box', {
+                    is_error: checkFieldState('channelSessionTtl', 'error'),
+                    is_success: checkFieldState('channelSessionTtl', 'success'),
+                  })}
+                >
+                  <InputTextField
+                    reset={() => {
+                      resetForm();
+                      resetUpdateFieldInfo();
+                    }}
+                    {...register('channelSessionTtl', {
+                      required: 'Channel Session TTL is required',
+                      pattern: {
+                        value: /^(\d{1,2}h\s?)?(\d{1,2}m\s?)?(\d{1,2}s)?$/,
+                        message: 'Channel Session TTL should be a duration string such as "15s" or "1m30s" (1s–5m)',
+                      },
+                      onChange: async () => {
+                        await trigger('channelSessionTtl');
+                      },
+                    })}
+                    onChange={(e) => {
+                      setUpdateFieldInfo((info) => ({ ...info, target: 'channelSessionTtl' }));
+                      channelSessionTtl.onChange(e.target.value);
+                    }}
+                    id="channelSessionTtl"
+                    label="channelSessionTtl"
+                    blindLabel={true}
+                    fieldUtil={true}
+                    placeholder={'15s'}
+                    state={
+                      checkFieldState('channelSessionTtl', 'success')
+                        ? 'success'
+                        : checkFieldState('channelSessionTtl', 'error')
+                          ? 'error'
+                          : undefined
+                    }
+                    helperText={
+                      updateFieldInfo.target === 'channelSessionTtl' && updateFieldInfo.state !== null
                         ? updateFieldInfo.message
                         : undefined
                     }

--- a/src/features/projects/projectsSlice.ts
+++ b/src/features/projects/projectsSlice.ts
@@ -353,7 +353,7 @@ export const projectsSlice = createSlice({
               target: 'clientDeactivateThreshold',
               message: description,
             };
-          } else if (field === 'ChannelSessionTtl') {
+          } else if (field === 'ChannelSessionTTL') {
             state.update.error = {
               target: 'channelSessionTtl',
               message: description,

--- a/src/features/projects/projectsSlice.ts
+++ b/src/features/projects/projectsSlice.ts
@@ -83,6 +83,7 @@ export type ProjectUpdateFields = {
   eventWebhookURL: string;
   eventWebhookEvents: Array<EventWebhookEvent>;
   clientDeactivateThreshold: string;
+  channelSessionTtl: string;
   snapshotThreshold: number;
   snapshotInterval: number;
   maxSubscribersPerDocument: number;
@@ -350,6 +351,11 @@ export const projectsSlice = createSlice({
           } else if (field === 'ClientDeactivateThreshold') {
             state.update.error = {
               target: 'clientDeactivateThreshold',
+              message: description,
+            };
+          } else if (field === 'ChannelSessionTtl') {
+            state.update.error = {
+              target: 'channelSessionTtl',
               message: description,
             };
           } else if (field === 'maxSubscribersPerDocument') {


### PR DESCRIPTION
## Summary

- Adds a Channel Session TTL form field to the project Settings page, mirroring the existing Client Deactivate Threshold pattern. Lets project owners tune how long presence-channel sessions are retained after the last refresh — useful for inflating the apparent live presence count in small rooms.
- Form validates duration string format client-side; the server enforces the 1s..5m bound (rejection surfaces on the field via the Redux error handler).
- Pairs with the backend change in [yorkie-team/yorkie#1827](https://github.com/yorkie-team/yorkie/pull/1827) (merged at `4f68cfd6`). The vendored `resources.proto` and `resources_pb.ts` are updated to match field numbers 28 (Project) and 23 (UpdatableProjectFields) from upstream.

## Test plan

- [x] `npm run build` — TypeScript + Vite pass
- [x] `npm run test` — 6/6 passing
- [x] `npm run build:proto` produces zero diff against committed `resources_pb.ts` (hand-edits match canonical buf output)
- [x] Manual: open project Settings, change Channel Session TTL to `1m`, save, reload — value persists
- [x] Manual: enter `0s` or `10m` — server rejection surfaces on the field with the bound message
- [x] Manual: enter malformed value (e.g. `abc`) — client-side pattern validation rejects it before submit