### PR TITLE
Format overview usage counts with thousand separators

### DIFF
--- a/src/features/projects/Overview.tsx
+++ b/src/features/projects/Overview.tsx
@@ -28,6 +28,7 @@ import { ActiveChannelChart } from './charts/ActiveChannelChart';
 import { SessionChart } from './charts/SessionChart';
 import { PeakSessionChart } from './charts/PeakSessionChart';
 import { Icon, Popover, Dropdown } from 'components';
+import { formatNumber } from 'utils';
 import { DATE_RANGE_OPTIONS } from 'api/types';
 import { ActiveDocumentChart } from './charts/ActiveDocumentChart';
 import { ActiveClientChart } from './charts/ActiveClientChart';
@@ -70,15 +71,15 @@ export function Overview() {
         <ul className="usage_list">
           <li className="usage_item link_type">
             <span className="title">Documents</span>
-            <span className="info_text">{String(stats?.documentsCount || 0)}</span>
+            <span className="info_text">{formatNumber(stats?.documentsCount)}</span>
           </li>
           <li className="usage_item link_type">
             <span className="title">Clients</span>
-            <span className="info_text">{String(stats?.clientsCount || 0)}</span>
+            <span className="info_text">{formatNumber(stats?.clientsCount)}</span>
           </li>
           <li className="usage_item link_type">
             <span className="title">Channels</span>
-            <span className="info_text">{String(stats?.channelsCount || 0)}</span>
+            <span className="info_text">{formatNumber(stats?.channelsCount)}</span>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## What

The Documents, Clients and Channels totals on the project overview were
rendered with `String()`, so a large count showed up as `1234567`. They now
go through the existing `formatNumber()` helper and read as `1,234,567`.

Every other count in the app — including the usage charts directly below on
the same screen (`UsageChart.tsx`), `DocumentList`, `ChannelList` and
`DocumentDetail` — already goes through `formatNumber()`. These three tiles
were the only place left out.

## Notes

The `|| 0` fallback is dropped because `formatNumber()` already maps
`undefined` to `'0'`. Behavior is unchanged for both `undefined` and `0`; only
values above 999 render differently.

No stylesheet changes. `usage.scss` sets no fixed width, `overflow: hidden`,
`text-overflow` or `white-space: nowrap` on these tiles, so the longer string
just widens the flex item.

## Verification

- `npm run build` passes
- `npm run test` passes (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved readability of document, client, and channel counts by displaying them with consistent number formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->