### PR TITLE
Format chart tooltip values with thousand separators

### DIFF
--- a/src/components/Chart/Chart.tsx
+++ b/src/components/Chart/Chart.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { LineChart, Line, XAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { formatNumber } from 'utils';
 
 export function Chart({ data, xKey, dataKey }: { data: any[]; xKey: string; dataKey: string }) {
   return (
@@ -32,7 +33,7 @@ export function Chart({ data, xKey, dataKey }: { data: any[]; xKey: string; data
       >
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey={xKey} tickSize={0} tickMargin={10} />
-        <Tooltip labelStyle={{ color: '#333' }} />
+        <Tooltip labelStyle={{ color: '#333' }} formatter={(value) => formatNumber(value as number)} />
         <Line type="monotone" dataKey={dataKey} stroke="orange" dot={{ r: 3 }} activeDot={{ stroke: 'none', r: 3 }} />
       </LineChart>
     </ResponsiveContainer>


### PR DESCRIPTION
## What

Apply thousand-separator formatting to the numbers shown in the chart tooltip on hover.

## Why

#306 formatted the overview usage counts with thousand separators, but the value shown in the chart tooltip when hovering over a data point still rendered a raw number (e.g. `12345` instead of `12,345`). This reuses the shared `formatNumber` helper so the tooltip is consistent with the rest of the dashboard.

## How

Add a `formatter` to the recharts `Tooltip` in the shared `Chart` component. Because `Chart` backs every usage chart (Active Channel/Client/Document/User, Session, Peak Session), the fix applies everywhere at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved line chart tooltips by formatting numeric values for clearer, more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->